### PR TITLE
Make new pub recognize credentials

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,12 @@ check_credentials() {
 
 copy_credential() {
   echo "Copy credentials"
-  mkdir -p ~/.pub-cache
-  cat <<EOF > ~/.pub-cache/credentials.json
+  mkdir -p ~/Library/Application\ Support/dart
+  cat <<EOF > ~/Library/Application\ Support/dart/pub-credentials.json
 $INPUT_CREDENTIAL
 EOF
+  mkdir -p ~/.pub-cache
+  ln -s ~/Library/Application\ Support/dart/pub-credentials.json credentials.json
   echo "OK"
 }
 


### PR DESCRIPTION
As the commit shows, the new pub will not create `~/.pub-cache/credentials.json` anymore. It uses `~/Library/Application\ Support\dart\pub-credentials.json` instead.

cc @sakebook 